### PR TITLE
Add Jest config and tests for fetchMatchDetails

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -36,6 +37,9 @@
     "postcss": "^8",
     "prettier": "^3.5.2",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
   }
 }

--- a/src/services/__tests__/matchService.test.ts
+++ b/src/services/__tests__/matchService.test.ts
@@ -1,0 +1,38 @@
+import { fetchMatchDetails } from '../matchService';
+
+describe('fetchMatchDetails', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  it('sends POST request to /api/scrape with correct body', async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({ homeTeam: {}, awayTeam: {}, link: 'l' }),
+    } as unknown as Response;
+
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    const result = await fetchMatchDetails('some-id');
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/scrape', {
+      method: 'POST',
+      body: JSON.stringify({ url: 'some-id' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(result).toEqual({ homeTeam: {}, awayTeam: {}, link: 'l' });
+  });
+
+  it('throws an error when response is not ok', async () => {
+    const mockResponse = { ok: false } as Response;
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    await expect(fetchMatchDetails('some-id')).rejects.toThrow(
+      'Failed to fetch match details'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add match service unit test
- configure Jest with ts-jest preset
- add test script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685003369f3883228391c2d8a1a49e98